### PR TITLE
FIX: Incorrect dataclass type in EmbeddingOutput

### DIFF
--- a/sae_auto_interp/scorers/embedding/embedding.py
+++ b/sae_auto_interp/scorers/embedding/embedding.py
@@ -24,7 +24,7 @@ class EmbeddingOutput:
     distance: float | int
     """Quantile or neighbor distance"""
 
-    similarity: list[float] = 0
+    similarity: float = 0
     """What is the similarity of the example to the explanation"""
 
 


### PR DESCRIPTION
The type for similarity in EmbeddingOutput should be a float, not a list[float].

Fixes #44 