### PR TITLE
FIX: Top logprob bug in Offline._parse_logprobs

### DIFF
--- a/sae_auto_interp/clients/offline.py
+++ b/sae_auto_interp/clients/offline.py
@@ -97,6 +97,7 @@ class Offline(Client):
         return await future
 
     def _parse_logprobs(self,response):
+        response_tokens = response.outputs[0].token_ids
         logprobs=response.outputs[0].logprobs
         prompt_logprobs=response.prompt_logprobs
         if logprobs is None and prompt_logprobs is None:
@@ -109,7 +110,7 @@ class Offline(Client):
                 top_logprobs = []
                 decoded_token = ""
                 for token, logprob in log_prob_dict.items():
-                    if logprob.rank==1:
+                    if token == response_tokens[i]:
                         decoded_token = logprob.decoded_token
                         top_logprobs.append(Top_Logprob(token=decoded_token, logprob=logprob.logprob))
                     else:


### PR DESCRIPTION
The current implementation sometimes picks up on the incorrect decoded token because it implicitly assumes that the model always picks the token with the highest logprob (which is what `logprob.rank==1` looks for). This leads to outputs such as these:
![Screenshot 2025-01-20 at 12 44 54 PM](https://github.com/user-attachments/assets/835aea2e-f5f1-4673-9ac1-5502a139bcab)
Notice how when you put together the `Logprobs.token`’s, you don’t get the same thing as the model's actual output (often because the model was "indecisive" between a number and a space). This then confuses `Classifier._parse_logprobs` which only looks at `Logprobs.token` to determine which sequence positions contain the model’s labels. In the case of the logs I screenshotted above, this leads to `Classifier._parse_logprobs` returning a list of the wrong length, which ultimately causes the assertion at `scorers/classifier/classifier.py:133` to fail.

My PR fixes this by always setting Logprobs.token to the actual token which the model chose, rather than the token it was maximally likely to choose (but may or may not have actually chosen).
