### PR TITLE
fix: failed_count is always zero in result analysis

### DIFF
--- a/delphi/log/result_analysis.py
+++ b/delphi/log/result_analysis.py
@@ -106,7 +106,7 @@ def compute_confusion(df: pd.DataFrame, threshold: float = 0.5) -> dict:
         total_examples=total,
         total_positives=pos,
         total_negatives=neg,
-        failed_count=len(df_valid) - total,
+        failed_count=len(df) - total,
     )
 
 

--- a/tests/test_log/test_result_analysis.py
+++ b/tests/test_log/test_result_analysis.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+
+from delphi.log.result_analysis import compute_confusion
+
+
+def test_failed_count_counts_dropped_predictions():
+    """
+    compute_confusion must report how many examples the scorer failed to
+    produce a (parseable) prediction for. Failed examples are stored with a
+    None/NaN ``prediction`` by the classifier and are dropped by the
+    ``prediction.notna()`` filter, so ``failed_count`` should equal the number
+    of rows removed by that filter, i.e. ``len(df) - len(valid rows)``.
+    """
+    df = pd.DataFrame(
+        {
+            "activating": [True, False, True, False],
+            # Two examples failed to be parsed -> NaN prediction.
+            "prediction": [1.0, 0.0, np.nan, np.nan],
+            "probability": [0.9, 0.1, np.nan, np.nan],
+        }
+    )
+
+    conf = compute_confusion(df)
+
+    assert conf["total_examples"] == 2
+    assert conf["failed_count"] == 2
+
+    # Mirror the "fraction of failed examples" computation in log_results().
+    fraction_failed = conf["failed_count"] / (
+        conf["total_examples"] + conf["failed_count"]
+    )
+    assert fraction_failed == 0.5
+
+
+def test_failed_count_zero_when_all_predictions_valid():
+    df = pd.DataFrame(
+        {
+            "activating": [True, False],
+            "prediction": [1.0, 0.0],
+            "probability": [0.9, 0.1],
+        }
+    )
+
+    conf = compute_confusion(df)
+
+    assert conf["total_examples"] == 2
+    assert conf["failed_count"] == 0


### PR DESCRIPTION
### problem
in `compute_confusion` (`delphi/log/result_analysis.py`), `failed_count` is computed as `len(df_valid) - total`, but `total` is itself `len(df_valid)`, so `failed_count` is always `0`. as a result the "Average fraction of failed examples" that `log_results` prints is always `0.0`, even when the scorer failed to produce a (parseable) prediction for many examples (those rows are dropped by the `prediction.notna()` filter earlier in the function).

### fix
```python
-        failed_count=len(df_valid) - total,
+        failed_count=len(df) - total,
```
`len(df) - total` is the number of rows removed by the `.notna()` filter, i.e. the examples that failed.

### test
added `tests/test_log/test_result_analysis.py` (pandas-only): builds a frame with 2 NaN predictions (what `classifier.py` stores when generation/parse fails) and asserts `failed_count == 2` and fraction `0.5`. fails on current main (`assert 0 == 2`), passes with the fix. ruff clean.

found by reading the code.
